### PR TITLE
first pass on documentation for TELEX modules

### DIFF
--- a/docs/ops/telex_i.md
+++ b/docs/ops/telex_i.md
@@ -1,0 +1,5 @@
+## TELEXi Teletype Input Expander
+
+The TELEXi (or TXi) is an input expander that adds 4 IN jacks and 4 PARAM knobs to the Teletype. There are jumpers on the back so you can hook more than one TXi to your Teletype simultaneously.
+
+Inputs added to the system by the TELEX modules are addressed sequentially: 1-4 are on your first module of any type, 5-8 are on the second, 9-12 on the third, and so on. A few of the commands reference the module by its unit number – but those are rare.

--- a/docs/ops/telex_i.toml
+++ b/docs/ops/telex_i.toml
@@ -1,0 +1,147 @@
+["TI.PARAM"]
+prototype = "TI.PARAM x"
+aliases = ["TI.PRM"]
+short = "reads the value of `PARAM` knob `x`; default return range is from 0 to 16383; return range can be altered by the `TI.PARAM.MAP` command"
+
+["TI.PARAM.QT"]
+prototype = "TI.PARAM.QT x"
+aliases = ["TI.PRM.QT"]
+short = "return the quantized value for `PARAM` knob `x` using the scale set by `TI.PARAM.SCALE`; default return range is from 0 to 16383"
+
+["TI.PARAM.N"]
+prototype = "TI.PARAM.N x"
+aliases = ["TI.PRM.N"]
+short = "return the quantized note number for `PARAM` knob `x` using the scale set by `TI.PARAM.SCALE`"
+
+["TI.PARAM.SCALE"]
+prototype_set = "TI.PARAM.SCALE x"
+aliases = ["TI.PRM.SCALE"]
+short = "select scale # `y` for `PARAM` knob `x`; scales listed in full description"
+description = """
+### Quantization Scales
+0. Equal Temperament [DEFAULT]
+1. 12-tone Pythagorean scale
+2. Vallotti & Young scale (Vallotti version) also known as Tartini-Vallotti (1754)
+3. Andreas Werckmeister's temperament III (the most famous one, 1681)
+4. Wendy Carlos' Alpha scale with perfect fifth divided in nine
+5. Wendy Carlos' Beta scale with perfect fifth divided by eleven
+6. Wendy Carlos' Gamma scale with third divided by eleven or fifth by twenty
+7. Carlos Harmonic & Ben Johnston's scale of 'Blues' from Suite f.micr.piano (1977) & David Beardsley's scale of 'Science Friction'
+8. Carlos Super Just
+9. Kurzweil "Empirical Arabic"
+10. Kurzweil "Just with natural b7th", is Sauveur Just with 7/4
+11. Kurzweil "Empirical Bali/Java Harmonic Pelog"
+12. Kurzweil "Empirical Bali/Java Slendro, Siam 7"
+13. Kurzweil "Empirical Tibetian Ceremonial"
+14. Harry Partch's 43-tone pure scale
+15. Partch's Indian Chromatic, Exposition of Monophony, 1933. 
+16. Partch Greek scales from "Two Studies on Ancient Greek Scales" on black/white 
+"""
+
+["TI.PARAM.MAP"]
+prototype_set = "TI.PARAM.MAP x y z"
+aliases = ["TI.PRM.MAP"]
+short = "maps the PARAM values for input `x` across the range y - z (defaults 0-16383)"
+description = """
+If you would like to have a `PARAM` knob values over a specific range, you can offload the processing for this to the TXo by mapping the range of the potentiometer using the `MAP` command. It works a lot like the `MAP` operator, but does the heavy lifting on the TXi, saving you space in your code and cycles on your processor.
+
+For instance, let's have the first knob return a range from 0 to 100.
+
+```
+TI.PARAM.MAP 1 0 100
+```
+
+You can reset the mapping by either calling the map command with the default range or by using the `INIT` command (`TO.PARAM.INIT 1`).
+"""
+
+["TI.IN"]
+prototype = "TI.IN x"
+short = "reads the value of IN jack `x`; default return range is from -16384 to 16383 - representing -10V to +10V; return range can be altered by the `TI.IN.MAP` command"
+
+["TI.IN.QT"]
+prototype = "TI.IN.QT x"
+short = "return the quantized value for `IN` jack `x` using the scale set by `TI.IN.SCALE`; default return range is from -16384 to 16383 - representing -10V to +10V"
+
+["TI.IN.N"]
+prototype = "TI.IN.N x"
+short = "return the quantized note number for `IN` jack `x` using the scale set by `TI.IN.SCALE`"
+
+["TI.IN.SCALE"]
+prototype_set = "TI.IN.SCALE x"
+short = "select scale # `y` for `IN` jack `x`; scales listed in full description"
+description = """
+### Quantization Scales
+0. Equal Temperament [DEFAULT]
+1. 12-tone Pythagorean scale
+2. Vallotti & Young scale (Vallotti version) also known as Tartini-Vallotti (1754)
+3. Andreas Werckmeister's temperament III (the most famous one, 1681)
+4. Wendy Carlos' Alpha scale with perfect fifth divided in nine
+5. Wendy Carlos' Beta scale with perfect fifth divided by eleven
+6. Wendy Carlos' Gamma scale with third divided by eleven or fifth by twenty
+7. Carlos Harmonic & Ben Johnston's scale of 'Blues' from Suite f.micr.piano (1977) & David Beardsley's scale of 'Science Friction'
+8. Carlos Super Just
+9. Kurzweil "Empirical Arabic"
+10. Kurzweil "Just with natural b7th", is Sauveur Just with 7/4
+11. Kurzweil "Empirical Bali/Java Harmonic Pelog"
+12. Kurzweil "Empirical Bali/Java Slendro, Siam 7"
+13. Kurzweil "Empirical Tibetian Ceremonial"
+14. Harry Partch's 43-tone pure scale
+15. Partch's Indian Chromatic, Exposition of Monophony, 1933. 
+16. Partch Greek scales from "Two Studies on Ancient Greek Scales" on black/white 
+"""
+
+["TI.IN.MAP"]
+prototype_set = "TI.IN.MAP x y z"
+short = "maps the IN values for input jack `x` across the range y - z (default range is -16384 to 16383 - representing -10V to +10V)"
+
+["TI.PARAM.INIT"]
+prototype_set = "TI.PARAM.INIT x"
+aliases = ["TI.PRM.INIT"]
+short = "initializes `PARAM` knob `x` back to the default boot settings and behaviors; neutralizes mapping (but not calibration)"
+
+["TI.IN.INIT"]
+prototype_set = "TI.IN.INIT x"
+short = "initializes `IN` jack `x` back to the default boot settings and behaviors; neutralizes mapping (but not calibration)"
+
+["TI.INIT"]
+prototype_set = "TI.INIT d"
+short = "initializes all of the `PARAM` and `IN` inputs for device number `d` (1-8)"
+
+["TI.PARAM.CALIB"]
+prototype_set = "TI.PARAM.CALIB x y"
+aliases = ["TI.PRM.CALIB"]
+short = "calibrates the scaling for PARAM knob `x`; `y` of `0` sets the bottom bound; `y` of `1` sets the top bound"
+description = """
+You can calibrate your `PARAM` knob by using this command. The steps for full calibration are as follows:
+
+1. Turn the PARAM knob `x` all the way to the left
+2. Send the command 'TI.PARAM.CALIBRATE x 0'
+3. Turn the PARAM knob `x` all the way to the right
+4. Send the command 'TI.PARAM.CALIBRATE x 1'
+
+Don't forget to call the `TI.STORE` command to save your calibration between sessions.
+"""
+
+["TI.IN.CALIB"]
+prototype_set = "TI.IN.CALIB x y"
+short = "calibrates the scaling for IN jack `x`; `y` of `-1` sets the `-10V` point; `y` of `0` sets the `0V` point; `y` of `1` sets the `+10V` point"
+description = """
+You can calibrate your `IN` jack to external voltages by using this command. The steps for full calibration are as follows:
+
+1. Send a `-10V` signal to the input `x`
+2. Send the command 'TI.IN.CALIBRATE x -1'
+3. Send a `0V` signal to the input `x`
+4. Send the command 'TI.IN.CALIBRATE x 0'
+5. Send a `10V` signal to the input `x`
+6. Send the command 'TI.IN.CALIBRATE x 1'
+
+Don't forget to call the `TI.STORE` command to save your calibration between sessions.
+"""
+
+["TI.STORE"]
+prototype_set = "TI.STORE d"
+short = "stores the calibration data for TXi number `d` (1-8) to its internal flash memory"
+
+["TI.RESET"]
+prototype_set = "TI.RESET d"
+short = "resets the calibration data for TXi number `d` (1-8) to its factory defaults (no calibration)"

--- a/docs/ops/telex_i.toml
+++ b/docs/ops/telex_i.toml
@@ -14,7 +14,7 @@ aliases = ["TI.PRM.N"]
 short = "return the quantized note number for `PARAM` knob `x` using the scale set by `TI.PARAM.SCALE`"
 
 ["TI.PARAM.SCALE"]
-prototype_set = "TI.PARAM.SCALE x"
+prototype = "TI.PARAM.SCALE x"
 aliases = ["TI.PRM.SCALE"]
 short = "select scale # `y` for `PARAM` knob `x`; scales listed in full description"
 description = """
@@ -39,7 +39,7 @@ description = """
 """
 
 ["TI.PARAM.MAP"]
-prototype_set = "TI.PARAM.MAP x y z"
+prototype = "TI.PARAM.MAP x y z"
 aliases = ["TI.PRM.MAP"]
 short = "maps the PARAM values for input `x` across the range y - z (defaults 0-16383)"
 description = """
@@ -67,7 +67,7 @@ prototype = "TI.IN.N x"
 short = "return the quantized note number for `IN` jack `x` using the scale set by `TI.IN.SCALE`"
 
 ["TI.IN.SCALE"]
-prototype_set = "TI.IN.SCALE x"
+prototype = "TI.IN.SCALE x"
 short = "select scale # `y` for `IN` jack `x`; scales listed in full description"
 description = """
 ### Quantization Scales
@@ -91,24 +91,24 @@ description = """
 """
 
 ["TI.IN.MAP"]
-prototype_set = "TI.IN.MAP x y z"
+prototype = "TI.IN.MAP x y z"
 short = "maps the IN values for input jack `x` across the range y - z (default range is -16384 to 16383 - representing -10V to +10V)"
 
 ["TI.PARAM.INIT"]
-prototype_set = "TI.PARAM.INIT x"
+prototype = "TI.PARAM.INIT x"
 aliases = ["TI.PRM.INIT"]
 short = "initializes `PARAM` knob `x` back to the default boot settings and behaviors; neutralizes mapping (but not calibration)"
 
 ["TI.IN.INIT"]
-prototype_set = "TI.IN.INIT x"
+prototype = "TI.IN.INIT x"
 short = "initializes `IN` jack `x` back to the default boot settings and behaviors; neutralizes mapping (but not calibration)"
 
 ["TI.INIT"]
-prototype_set = "TI.INIT d"
+prototype = "TI.INIT d"
 short = "initializes all of the `PARAM` and `IN` inputs for device number `d` (1-8)"
 
 ["TI.PARAM.CALIB"]
-prototype_set = "TI.PARAM.CALIB x y"
+prototype = "TI.PARAM.CALIB x y"
 aliases = ["TI.PRM.CALIB"]
 short = "calibrates the scaling for PARAM knob `x`; `y` of `0` sets the bottom bound; `y` of `1` sets the top bound"
 description = """
@@ -123,7 +123,7 @@ Don't forget to call the `TI.STORE` command to save your calibration between ses
 """
 
 ["TI.IN.CALIB"]
-prototype_set = "TI.IN.CALIB x y"
+prototype = "TI.IN.CALIB x y"
 short = "calibrates the scaling for IN jack `x`; `y` of `-1` sets the `-10V` point; `y` of `0` sets the `0V` point; `y` of `1` sets the `+10V` point"
 description = """
 You can calibrate your `IN` jack to external voltages by using this command. The steps for full calibration are as follows:
@@ -139,9 +139,9 @@ Don't forget to call the `TI.STORE` command to save your calibration between ses
 """
 
 ["TI.STORE"]
-prototype_set = "TI.STORE d"
+prototype = "TI.STORE d"
 short = "stores the calibration data for TXi number `d` (1-8) to its internal flash memory"
 
 ["TI.RESET"]
-prototype_set = "TI.RESET d"
+prototype = "TI.RESET d"
 short = "resets the calibration data for TXi number `d` (1-8) to its factory defaults (no calibration)"

--- a/docs/ops/telex_o.md
+++ b/docs/ops/telex_o.md
@@ -1,0 +1,7 @@
+## TELEXo Teletype Output Expander
+
+The TELEXo (or TXo) is an output expander that adds an additional 4 Trigger and 4 CV jacks to the Teletype. There are jumpers on the back so you can hook more than one TXo to your Teletype simultaneously.
+
+Outputs added to the system by the TELEX modules are addressed sequentially: 1-4 are on your first module of any type, 5-8 are on the second, 9-12 on the third, and so on. A few of the commands reference the module by its unit number – but those are rare.
+
+Unlike the Teletype's equivalent operators, the TXo does not have get commands for its functions. This was intentional as these commands eat up processor and bus-space. While they may be added in the future, as of now you cannot poll the TXo for the current state of its various operators.

--- a/docs/ops/telex_o.toml
+++ b/docs/ops/telex_o.toml
@@ -1,0 +1,402 @@
+["TO.TR"]
+prototype_set = "TO.TR x y"
+short = "sets the `TR` value for output `x` to `y` (0/1)"
+
+["TO.TR.TOG"]
+prototype_set = "TO.TR.TOG x"
+short = "toggles the `TR` value for output `x`"
+
+["TO.TR.PULSE"]
+prototype_set = "TO.TR.PULSE x"
+aliases = ["TO.TR.P"]
+short = "pulses the `TR` value for output `x` for the duration set by `TO.TR.TIME/S/M`"
+
+["TO.TR.PULSE.DIV"]
+prototype_set = "TO.TR.PULSE.DIV x y"
+aliases = ["TO.TR.P.DIV"]
+short = "sets the clock division factor for `TR` output `x` to `y`"
+description = """
+The pulse divider will output one trigger pulse every `y` pulse commands. For example, setting the `DIV` factor to `2` like this:
+```
+TO.TR.P.DIV 1 2
+```
+Will cause every other `TO.TR.P 1` command to emit a pulse.
+
+Reset it to one (`TO.TR.P.DIV 1 1`) or initialize the output (`TO.TR.INIT 1`) to return to the default behavior.
+"""
+
+["TO.TR.TIME"]
+prototype_set = "TO.TR.TIME x y"
+short = "sets the time for `TR.PULSE` on output `n`; `y` in milliseconds"
+
+["TO.TR.TIME.S"]
+prototype_set = "TO.TR.TIME.S x y"
+short = "sets the time for `TR.PULSE` on output `n`; `y` in seconds"
+
+["TO.TR.TIME.M"]
+prototype_set = "TO.TR.TIME.M x y"
+short = "sets the time for `TR.PULSE` on output `n`; `y` in minutes"
+
+["TO.TR.WIDTH"]
+prototype_set = "TO.TR.WIDTH x y"
+short = "sets the time for `TR.PULSE` on output `n` based on the width of its current metronomic value; `y` in percentage (0-100)"
+description = """
+The actual time value for the trigger pulse when set by the `WIDTH` command is relative to the current value for `TO.TR.M`. Changes to `TO.TR.M` will change the duration of `TR.PULSE` when using the `WIDTH` mode to set its value. Values for `y` are set in percentage (0-100).
+
+For example:
+
+```
+TO.TR.M 1 1000
+TO.TR.WIDTH 1 50
+```
+
+The length of a `TR.PULSE` is now 500ms.
+
+```
+TO.TR.M 1 500
+```
+
+The length of a `TR.PULSE` is now 250ms. Note that you don't need to use the width command again as it automatically tracks the value for `TO.TR.M`.
+"""
+
+["TO.TR.POL"]
+prototype_set = "TO.TR.POL x y"
+short = "sets the polarity for `TR` output `n`"
+
+["TO.TR.M.ACT"]
+prototype_set = "TO.TR.M.ACT x y"
+short = "sets the active status for the independent metronome for output `x` to `y` (`0`/`1`); default `0` (disabled)"
+description = """
+Each `TR` output has its own independent metronome that will execute a `TR.PULSE` at a specified interval. The `ACT` command enables (1) or disables (0) the metronome.
+"""
+
+["TO.TR.M"]
+prototype_set = "TO.TR.M x y"
+short = "sets the independent metronome interval for output `x` to `y` in milliseconds; default `1000`"
+
+["TO.TR.M.S"]
+prototype_set = "TO.TR.M.S x y"
+short = "sets the independent metronome interval for output `x` to `y` in seconds; default `1`"
+
+["TO.TR.M.M"]
+prototype_set = "TO.TR.M.M x y"
+short = "sets the independent metronome interval for output `x` to `y` in minutes"
+
+["TO.TR.M.BPM"]
+prototype_set = "TO.TR.M.BPM x y"
+short = "sets the independent metronome interval for output `x` to `y` in Beats Per Minute"
+
+["TO.TR.M.COUNT"]
+prototype_set = "TO.TR.M.COUNT x y"
+short = "sets the number of repeats before deactivating for output `x` to `y`; default `0` (infinity)"
+description = """
+This allows for setting a limit to the number of times `TO.TR.M` will `PULSE` when active before automatically disabling itself. For example, let's set it to pulse 5 times with 500ms between pulses:
+
+```
+TO.TR.M 1 500
+TO.TR.M.COUNT 1 5
+```
+
+Now, each time we activate it, the metronome will pulse 5 times - each a half-second apart.
+
+```
+TO.TR.M.ACT 1 1
+```
+
+`PULSE` ... `PULSE` ... `PULSE` ... `PULSE` ... `PULSE`.
+
+The metronome is now disabled after pulsing five times. If you call `ACT` again, it will emit five more pulses.
+
+To reset, either set your `COUNT` to zero (`TO.TR.M.COUNT 1 0`) or call init on the output (`TO.TR.INIT 1 1`).
+"""
+
+["TO.TR.M.SYNC"]
+prototype_set = "TO.TR.M.SYNC d"
+short = "synchronizes the metronomes for device number `d` (1-8)"
+description = """
+This command causes the TXo at device `d` to synchronize all of its independent metronomes to the moment it receives the command. Each will then continue to pulse at its own independent `M` rate.
+"""
+
+["TO.CV"]
+prototype_set = "TO.CV x"
+short = "CV target output `x`; `y` values are bipolar (-16384 to +16383) and map to -10 to +10"
+
+["TO.CV.SLEW"]
+prototype_set = "TO.CV.SLEW x y"
+short = "set the slew amount for output `x`; `y` in milliseconds"
+
+["TO.CV.SLEW.S"]
+prototype_set = "TO.CV.SLEW.S x y"
+short = "set the slew amount for output `x`; `y` in seconds"
+
+["TO.CV.SLEW.M"]
+prototype_set = "TO.CV.SLEW.M x y"
+short = "set the slew amount for output `x`; `y` in minutes"
+
+["TO.CV.SET"]
+prototype_set = "TO.CV.SET x y"
+short = "set the CV for output `x` (ignoring `SLEW`); `y` values are bipolar (-16384 to +16383) and map to -10 to +10"
+
+["TO.CV.OFF"]
+prototype_set = "TO.CV.OFF x y"
+short = "set the CV offset for output `x`; `y` values are added at the final stage"
+
+["TO.CV.QT"]
+prototype_set = "TO.CV.QT x y"
+short = "CV target output `x`; `y` is quantized to output's current `CV.SCALE`"
+
+["TO.CV.QT.SET"]
+prototype_set = "TO.CV.QT.SET x y"
+short = "set the CV for output `x` (ignoring `SLEW`); `y` is quantized to output's current `CV.SCALE`"
+
+["TO.CV.N"]
+prototype_set = "TO.CV.N x y"
+short = "target the CV to note `y` for output `x`; `y` is indexed in the output's current `CV.SCALE`"
+
+["TO.CV.N.SET"]
+prototype_set = "TO.CV.N.SET x y"
+short = "set the CV to note `y` for output `x`; `y` is indexed in the output's current `CV.SCALE` (ignoring `SLEW`)"
+
+["TO.CV.SCALE"]
+prototype_set = "TO.CV.SCALE x y"
+short = "select scale # `y` for CV output `x`; scales listed in full description"
+description = """
+### Quantization Scales
+0. Equal Temperament [DEFAULT]
+1. 12-tone Pythagorean scale
+2. Vallotti & Young scale (Vallotti version) also known as Tartini-Vallotti (1754)
+3. Andreas Werckmeister's temperament III (the most famous one, 1681)
+4. Wendy Carlos' Alpha scale with perfect fifth divided in nine
+5. Wendy Carlos' Beta scale with perfect fifth divided by eleven
+6. Wendy Carlos' Gamma scale with third divided by eleven or fifth by twenty
+7. Carlos Harmonic & Ben Johnston's scale of 'Blues' from Suite f.micr.piano (1977) & David Beardsley's scale of 'Science Friction'
+8. Carlos Super Just
+9. Kurzweil "Empirical Arabic"
+10. Kurzweil "Just with natural b7th", is Sauveur Just with 7/4
+11. Kurzweil "Empirical Bali/Java Harmonic Pelog"
+12. Kurzweil "Empirical Bali/Java Slendro, Siam 7"
+13. Kurzweil "Empirical Tibetian Ceremonial"
+14. Harry Partch's 43-tone pure scale
+15. Partch's Indian Chromatic, Exposition of Monophony, 1933. 
+16. Partch Greek scales from "Two Studies on Ancient Greek Scales" on black/white 
+"""
+
+["TO.OSC"]
+prototype_set = "TO.OSC x y"
+short = "targets oscillation for CV output `x` to `y` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is 1v/oct translated from the standard range (1-16384); a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+description = """
+Setting an `OSC` frequency greater than zero for a `CV` output will start that output oscillating. It will swing its voltage between to the current `CV` value and its polar opposite. For example:
+
+```
+TO.CV 1 V 5
+TO.OSC 1 N 69
+```
+
+This will emit the audio-rate note A (at 440Hz) swinging from '+5V' to '-5V'. The `CV` value acts as an amplitude control. For example:
+
+```
+TO.CV.SLEW.M 1 1
+TO.CV 1 V 10
+```
+
+This will cause the oscillations to gradually increase in amplitude from `5V` to `10V` over a period of one minute.
+
+**IMPORANT:** if you do not set a `CV` value, the oscillator will not emit a signal.
+
+If you want to go back to regular `CV` behavior, you need to set the oscillation frequency to zero. E.g. `TO.OSC 1 0`. You can also initialize the `CV` output with `TO.CV.INIT 1`, which resets all of its settings back to start-up default.
+
+"""
+
+["TO.OSC.SET"]
+prototype_set = "TO.OSC.SET x y"
+short = "set oscillation for CV output `x` to `y` (ignores `CV.OSC.SLEW`); `y` is 1v/oct translated from the standard range (1-16384); a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+
+["TO.OSC.QT"]
+prototype_set = "TO.OSC.QT x y"
+short = "targets oscillation for CV output `x` to `y` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is 1v/oct translated from the standard range (1-16384) and quantized to current `OSC.SCALE`; a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+
+["TO.OSC.QT.SET"]
+prototype_set = "TO.OSC.QT.SET x y"
+short = "set oscillation for CV output `x` to `y` (ignores `CV.OSC.SLEW`); `y` is 1v/oct translated from the standard range (1-16384) and quantized to current `OSC.SCALE`; a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+
+["TO.OSC.N"]
+prototype_set = "TO.OSC.N x y"
+short = "targets oscillation for CV output `x` to note `y` with the portamento rate determined by the `TO.OSC.SLEW` value; see quantization scale reference for `y`; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+
+["TO.OSC.N.SET"]
+prototype_set = "TO.OSC.N.SET x y"
+short = "sets oscillation for CV output `x` to note `y` (ignores `CV.OSC.SLEW`); see quantization scale reference for `y`; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+
+["TO.OSC.FQ"]
+prototype_set = "TO.OSC.FQ x y"
+short = "targets oscillation for CV output `x` to frequency `y` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in Hz; a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+
+["TO.OSC.FQ.SET"]
+prototype_set = "TO.OSC.FQ x y"
+short = "sets oscillation for CV output `x` to frequency `y` (ignores `CV.OSC.SLEW`); `y` is in Hz; a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+
+["TO.OSC.LFO"]
+prototype_set = "TO.OSC.LFO x y"
+short = "targets oscillation for CV output `x` to LFO frequency `y` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in mHz (millihertz: 10^-3 Hz); a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+
+["TO.OSC.LFO.SET"]
+prototype_set = "TO.OSC.LFO.SET x y"
+short = "sets oscillation for CV output `x` to LFO frequency `y` (ignores `CV.OSC.SLEW`); `y` is in mHz (millihertz: 10^-3 Hz); a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
+
+["TO.OSC.SCALE"]
+prototype_set = "TO.OSC.SCALE x y"
+short = "select scale # `y` for CV output `x`; scales listed in full description"
+description = """
+### Quantization Scales
+0. Equal Temperament [DEFAULT]
+1. 12-tone Pythagorean scale
+2. Vallotti & Young scale (Vallotti version) also known as Tartini-Vallotti (1754)
+3. Andreas Werckmeister's temperament III (the most famous one, 1681)
+4. Wendy Carlos' Alpha scale with perfect fifth divided in nine
+5. Wendy Carlos' Beta scale with perfect fifth divided by eleven
+6. Wendy Carlos' Gamma scale with third divided by eleven or fifth by twenty
+7. Carlos Harmonic & Ben Johnston's scale of 'Blues' from Suite f.micr.piano (1977) & David Beardsley's scale of 'Science Friction'
+8. Carlos Super Just
+9. Kurzweil "Empirical Arabic"
+10. Kurzweil "Just with natural b7th", is Sauveur Just with 7/4
+11. Kurzweil "Empirical Bali/Java Harmonic Pelog"
+12. Kurzweil "Empirical Bali/Java Slendro, Siam 7"
+13. Kurzweil "Empirical Tibetian Ceremonial"
+14. Harry Partch's 43-tone pure scale
+15. Partch's Indian Chromatic, Exposition of Monophony, 1933. 
+16. Partch Greek scales from "Two Studies on Ancient Greek Scales" on black/white 
+"""
+
+["TO.OSC.CYC"]
+prototype_set = "TO.OSC.CYC x y"
+short = "targets the oscillator cycle length to `y` for CV output `x` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in milliseconds"
+
+["TO.OSC.CYC.SET"]
+prototype_set = "TO.OSC.CYC.SET x y"
+short = "sets the oscillator cycle length to `y` for CV output `x` (ignores `CV.OSC.SLEW`); `y` is in milliseconds"
+
+["TO.OSC.CYC.S"]
+prototype_set = "TO.OSC.CYC.S x y"
+short = "targets the oscillator cycle length to `y` for CV output `x` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in seconds"
+
+["TO.OSC.CYC.S.SET"]
+prototype_set = "TO.OSC.CYC.S.SET x y"
+short = "sets the oscillator cycle length to `y` for CV output `x` (ignores `CV.OSC.SLEW`); `y` is in seconds"
+
+["TO.OSC.CYC.M"]
+prototype_set = "TO.OSC.CYC.M x y"
+short = "targets the oscillator cycle length to `y` for CV output `x` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in minutes"
+
+["TO.OSC.CYC.M.SET"]
+prototype_set = "TO.OSC.CYC.M.SET x y"
+short = "sets the oscillator cycle length to `y` for CV output `x` (ignores `CV.OSC.SLEW`); `y` is in minutes"
+
+["TO.OSC.WAVE"]
+prototype_set = "TO.OSC.WAVE x y"
+short = "set the waveform for output `x` to `y`; `y` values range `0-4999`; values translate to sine (0), triangle (1000), saw (2000), pulse (3000), or noise (4000); oscillator shape between values is a blend of the pure waveforms"
+
+["TO.OSC.WIDTH"]
+prototype_set = "TO.OSC.WIDTH x y"
+short = "sets the width of the pulse wave on output `x` to `y`; `y` is a percentage of total width (0 to 100); only affects waveform `3000`"
+
+["TO.OSC.SYNC"]
+prototype_set = "TO.OSC.SYNC x"
+short = "resets the phase of the oscillator on `CV` output `x` (relative to `TO.OSC.PHASE`)"
+
+["TO.OSC.PHASE"]
+prototype_set = "TO.OSC.PHASE x y"
+short = "sets the phase offset of the oscillator on CV output `x` to `y` (0 to 16383); `y` is the range of one cycle"
+
+["TO.OSC.RECT"]
+prototype_set = "TO.OSC.RECT x y"
+short = "rectifies the polarity of the oscillator for output `x` to `y`; range for `y` is -2 to 2; default is 0 (no rectification); 1 & -1 are partial rectification - omitting all values on the other side of the sign; 2 & -2 are full rectification - inverting values from the other pole"
+description = """
+The rectification command performs a couple of levels of rectification based on how you have it set. The following values for `y` work as follows:
+* `y = 2`: "full-positive" - inverts negative values, making them positive
+* `y = 1`: "half-positive" - omits all negative values (values below zero are set to zero)
+* `y = 0`: no rectification (default)
+* `y = -1`: "half-negative" - omits all positive values (values above zero are set to zero)
+* `y = -2`: "full-negative" - inverts positive values, making them negative
+"""
+
+["TO.OSC.SLEW"]
+prototype_set = "TO.OSC.SLEW x y"
+short = "sets the frequency slew time (portamento) for the oscillator on CV output `x` to `y`; `y` in milliseconds"
+description = """
+This parameter acts as a frequency slew for the targeted `CV` output. It allows you to gradually slide from one frequency to another, creating a portamento like effect. It is also great for smoothing transitions between different `LFO` rates on the oscillator. For example:
+
+```
+TO.CV 1 V 5
+TO.OSC.SLEW 1 30000
+TO.OSC.LFO.SET 1 1000
+TO.OSC.LFO 1 100
+```
+
+This will start an LFO on `CV 1` with a rate of 1000mHz. Then, over the next 30 seconds, it will gradually decrease in rate to 100mHz.
+"""
+
+["TO.OSC.SLEW.S"]
+prototype_set = "TO.OSC.SLEW.S x y"
+short = "sets the frequency slew time (portamento) for the oscillator on CV output `x` to `y`; `y` in seconds"
+
+["TO.OSC.SLEW.M"]
+prototype_set = "TO.OSC.SLEW.M x y"
+short = "sets the frequency slew time (portamento) for the oscillator on CV output `x` to `y`; `y` in minutes"
+
+["TO.ENV.ACT"]
+prototype_set = "TO.ENV.ACT x y"
+short = "activates/deactivates the AD envelope generator for the CV output `x`; `y` turns the envelope generator off (0 - default) or on (1);  `CV` amplitude is used as the peak for the envelope and needs to be `> 0` for the envelope to be perceivable"
+description = """
+This setting activates (1) or deactivates (0) the envelope generator on `CV` output `y`. The envelope generator is dependent on the current voltage setting for the output. Upon activation, the targeted output will go to zero. Then, when triggered (`TO.ENV.TRIG`), it will ramp the voltage from zero to the currently set peak voltage (`TO.CV`) over the attack time (`TO.ENV.ATT`) and then decay back to zero over the decay time (`TO.ENV.DEC`). For example:
+
+```
+TO.CV.SET 1 V 8
+TO.ENV.ACT 1 1
+TO.ENV.ATT.S 1 1
+TO.ENV.DEC.S 1 30
+```
+
+This will initialize the `CV 1` output to have an envelope that will ramp to `+8V` over one second and decay back to zero over thirty seconds. To trigger the envelope, you need to send the trigger command `TO.ENV.TRIG 1`. Envelopes currently re-trigger from the start of the cycle.
+
+To return your `CV` output to normal function, either deactivate the envelope (`TO.ENV.ACT 1 0`) or reinitialize the output (`TO.CV.INIT 1`).
+"""
+
+["TO.ENV.TRIG"]
+prototype_set = "TO.ENV.TRIG x"
+short = "triggers the envelope at `CV` output `x` to cycle;  `CV` amplitude is used as the peak for the envelope and needs to be `> 0` for the envelope to be perceivable"
+
+["TO.ENV.ATT"]
+prototype_set = "TO.ENV.ATT x y"
+short = "set the envelope attack time to `y` for `CV` output `x`; `y` in milliseconds (default 12 ms)"
+
+["TO.ENV.ATT.S"]
+prototype_set = "TO.ENV.ATT.S x y"
+short = "set the envelope attack time to `y` for `CV` output `x`; `y` in seconds"
+
+["TO.ENV.ATT.M"]
+prototype_set = "TO.ENV.ATT.M x y"
+short = "set the envelope attack time to `y` for `CV` output `x`; `y` in minutes"
+
+["TO.ENV.DEC"]
+prototype_set = "TO.ENV.DEC x y"
+short = "set the envelope decay time to `y` for `CV` output `x`; `y` in milliseconds (default 250 ms)"
+
+["TO.ENV.DEC.S"]
+prototype_set = "TO.ENV.DEC.S x y"
+short = "set the envelope decay time to `y` for `CV` output `x`; `y` in seconds"
+
+["TO.ENV.DEC.M"]
+prototype_set = "TO.ENV.DEC.M x y"
+short = "set the envelope decay time to `y` for `CV` output `x`; `y` in minutes"
+
+["TO.TR.INIT"]
+prototype_set = "TO.TR.INIT x"
+short = "initializes `TR` output `x` back to the default boot settings and behaviors; neutralizes metronomes, dividers, pulse counters, etc."
+
+["TO.CV.INIT"]
+prototype_set = "TO.CV.INIT x"
+short = "initializes `CV` output `x` back to the default boot settings and behaviors; neutralizes offsets, slews, envelopes, oscillation, etc."
+
+["TO.INIT"]
+prototype_set = "TO.INIT d"
+short = "initializes all of the `TR` and `CV` outputs for device number `d` (1-8)"

--- a/docs/ops/telex_o.toml
+++ b/docs/ops/telex_o.toml
@@ -1,18 +1,18 @@
 ["TO.TR"]
-prototype_set = "TO.TR x y"
+prototype = "TO.TR x y"
 short = "sets the `TR` value for output `x` to `y` (0/1)"
 
 ["TO.TR.TOG"]
-prototype_set = "TO.TR.TOG x"
+prototype = "TO.TR.TOG x"
 short = "toggles the `TR` value for output `x`"
 
 ["TO.TR.PULSE"]
-prototype_set = "TO.TR.PULSE x"
+prototype = "TO.TR.PULSE x"
 aliases = ["TO.TR.P"]
 short = "pulses the `TR` value for output `x` for the duration set by `TO.TR.TIME/S/M`"
 
 ["TO.TR.PULSE.DIV"]
-prototype_set = "TO.TR.PULSE.DIV x y"
+prototype = "TO.TR.PULSE.DIV x y"
 aliases = ["TO.TR.P.DIV"]
 short = "sets the clock division factor for `TR` output `x` to `y`"
 description = """
@@ -25,20 +25,25 @@ Will cause every other `TO.TR.P 1` command to emit a pulse.
 Reset it to one (`TO.TR.P.DIV 1 1`) or initialize the output (`TO.TR.INIT 1`) to return to the default behavior.
 """
 
+["TO.TR.PULSE.MUTE"]
+prototype = "TO.TR.PULSE.MUTE x y"
+aliases = ["TO.TR.P.MUTE"]
+short = "mutes or un-mutes `TR` output `x`; `y` is 1 (mute) or 0 (un-mute)"
+
 ["TO.TR.TIME"]
-prototype_set = "TO.TR.TIME x y"
+prototype = "TO.TR.TIME x y"
 short = "sets the time for `TR.PULSE` on output `n`; `y` in milliseconds"
 
 ["TO.TR.TIME.S"]
-prototype_set = "TO.TR.TIME.S x y"
+prototype = "TO.TR.TIME.S x y"
 short = "sets the time for `TR.PULSE` on output `n`; `y` in seconds"
 
 ["TO.TR.TIME.M"]
-prototype_set = "TO.TR.TIME.M x y"
+prototype = "TO.TR.TIME.M x y"
 short = "sets the time for `TR.PULSE` on output `n`; `y` in minutes"
 
 ["TO.TR.WIDTH"]
-prototype_set = "TO.TR.WIDTH x y"
+prototype = "TO.TR.WIDTH x y"
 short = "sets the time for `TR.PULSE` on output `n` based on the width of its current metronomic value; `y` in percentage (0-100)"
 description = """
 The actual time value for the trigger pulse when set by the `WIDTH` command is relative to the current value for `TO.TR.M`. Changes to `TO.TR.M` will change the duration of `TR.PULSE` when using the `WIDTH` mode to set its value. Values for `y` are set in percentage (0-100).
@@ -60,34 +65,34 @@ The length of a `TR.PULSE` is now 250ms. Note that you don't need to use the wid
 """
 
 ["TO.TR.POL"]
-prototype_set = "TO.TR.POL x y"
+prototype = "TO.TR.POL x y"
 short = "sets the polarity for `TR` output `n`"
 
 ["TO.TR.M.ACT"]
-prototype_set = "TO.TR.M.ACT x y"
+prototype = "TO.TR.M.ACT x y"
 short = "sets the active status for the independent metronome for output `x` to `y` (`0`/`1`); default `0` (disabled)"
 description = """
 Each `TR` output has its own independent metronome that will execute a `TR.PULSE` at a specified interval. The `ACT` command enables (1) or disables (0) the metronome.
 """
 
 ["TO.TR.M"]
-prototype_set = "TO.TR.M x y"
+prototype = "TO.TR.M x y"
 short = "sets the independent metronome interval for output `x` to `y` in milliseconds; default `1000`"
 
 ["TO.TR.M.S"]
-prototype_set = "TO.TR.M.S x y"
+prototype = "TO.TR.M.S x y"
 short = "sets the independent metronome interval for output `x` to `y` in seconds; default `1`"
 
 ["TO.TR.M.M"]
-prototype_set = "TO.TR.M.M x y"
+prototype = "TO.TR.M.M x y"
 short = "sets the independent metronome interval for output `x` to `y` in minutes"
 
 ["TO.TR.M.BPM"]
-prototype_set = "TO.TR.M.BPM x y"
+prototype = "TO.TR.M.BPM x y"
 short = "sets the independent metronome interval for output `x` to `y` in Beats Per Minute"
 
 ["TO.TR.M.COUNT"]
-prototype_set = "TO.TR.M.COUNT x y"
+prototype = "TO.TR.M.COUNT x y"
 short = "sets the number of repeats before deactivating for output `x` to `y`; default `0` (infinity)"
 description = """
 This allows for setting a limit to the number of times `TO.TR.M` will `PULSE` when active before automatically disabling itself. For example, let's set it to pulse 5 times with 500ms between pulses:
@@ -110,55 +115,96 @@ The metronome is now disabled after pulsing five times. If you call `ACT` again,
 To reset, either set your `COUNT` to zero (`TO.TR.M.COUNT 1 0`) or call init on the output (`TO.TR.INIT 1 1`).
 """
 
+["TO.TR.M.MUL"]
+prototype = "TO.TR.M.MUL x y"
+short = "multiplies the `M` rate on `TR` output `x` by `y`; `y` defaults to `1` - no multiplication"
+description = """
+The following example will cause 2 against 3 patterns to pulse out of `TO.TR` outputs `3` and `4`.
+
+```
+TO.TR.M.MUL 3 2
+TO.TR.M.MUL 4 3
+L 3 4: TO.TR.M.ACT I 1
+```
+"""
+
 ["TO.TR.M.SYNC"]
-prototype_set = "TO.TR.M.SYNC d"
-short = "synchronizes the metronomes for device number `d` (1-8)"
+prototype = "TO.TR.M.SYNC x"
+short = "synchronizes the `PULSE` for metronome on `TR` output number `x`"
+
+["TO.M.ACT"]
+prototype = "TO.M.ACT d y"
+short = "sets the active status for the 4 independent metronomes on device `d` (1-8) to `y` (`0`/`1`); default `0` (disabled)"
+
+["TO.M"]
+prototype = "TO.M d y"
+short = "sets the 4 independent metronome intervals for device `d` (1-8) to `y` in milliseconds; default `1000`"
+
+["TO.M.S"]
+prototype = "TO.M.S d y"
+short = "sets the 4 independent metronome intervals for device `d` to `y` in seconds; default `1`"
+
+["TO.M.M"]
+prototype = "TO.M.M d y"
+short = "sets the 4 independent metronome intervals for device `d` to `y` in minutes"
+
+["TO.M.BPM"]
+prototype = "TO.M.BPM d y"
+short = "sets the 4 independent metronome intervals for device `d` to `y` in Beats Per Minute"
+
+["TO.M.COUNT"]
+prototype = "TO.M.COUNT d y"
+short = "sets the number of repeats before deactivating for the 4 metronomes on device `d` to `y`; default `0` (infinity)"
+
+["TO.M.SYNC"]
+prototype = "TO.M.SYNC d"
+short = "synchronizes the 4 metronomes for device number `d` (1-8)"
 description = """
 This command causes the TXo at device `d` to synchronize all of its independent metronomes to the moment it receives the command. Each will then continue to pulse at its own independent `M` rate.
 """
 
 ["TO.CV"]
-prototype_set = "TO.CV x"
+prototype = "TO.CV x"
 short = "CV target output `x`; `y` values are bipolar (-16384 to +16383) and map to -10 to +10"
 
 ["TO.CV.SLEW"]
-prototype_set = "TO.CV.SLEW x y"
+prototype = "TO.CV.SLEW x y"
 short = "set the slew amount for output `x`; `y` in milliseconds"
 
 ["TO.CV.SLEW.S"]
-prototype_set = "TO.CV.SLEW.S x y"
+prototype = "TO.CV.SLEW.S x y"
 short = "set the slew amount for output `x`; `y` in seconds"
 
 ["TO.CV.SLEW.M"]
-prototype_set = "TO.CV.SLEW.M x y"
+prototype = "TO.CV.SLEW.M x y"
 short = "set the slew amount for output `x`; `y` in minutes"
 
 ["TO.CV.SET"]
-prototype_set = "TO.CV.SET x y"
+prototype = "TO.CV.SET x y"
 short = "set the CV for output `x` (ignoring `SLEW`); `y` values are bipolar (-16384 to +16383) and map to -10 to +10"
 
 ["TO.CV.OFF"]
-prototype_set = "TO.CV.OFF x y"
+prototype = "TO.CV.OFF x y"
 short = "set the CV offset for output `x`; `y` values are added at the final stage"
 
 ["TO.CV.QT"]
-prototype_set = "TO.CV.QT x y"
+prototype = "TO.CV.QT x y"
 short = "CV target output `x`; `y` is quantized to output's current `CV.SCALE`"
 
 ["TO.CV.QT.SET"]
-prototype_set = "TO.CV.QT.SET x y"
+prototype = "TO.CV.QT.SET x y"
 short = "set the CV for output `x` (ignoring `SLEW`); `y` is quantized to output's current `CV.SCALE`"
 
 ["TO.CV.N"]
-prototype_set = "TO.CV.N x y"
+prototype = "TO.CV.N x y"
 short = "target the CV to note `y` for output `x`; `y` is indexed in the output's current `CV.SCALE`"
 
 ["TO.CV.N.SET"]
-prototype_set = "TO.CV.N.SET x y"
+prototype = "TO.CV.N.SET x y"
 short = "set the CV to note `y` for output `x`; `y` is indexed in the output's current `CV.SCALE` (ignoring `SLEW`)"
 
 ["TO.CV.SCALE"]
-prototype_set = "TO.CV.SCALE x y"
+prototype = "TO.CV.SCALE x y"
 short = "select scale # `y` for CV output `x`; scales listed in full description"
 description = """
 ### Quantization Scales
@@ -181,8 +227,28 @@ description = """
 16. Partch Greek scales from "Two Studies on Ancient Greek Scales" on black/white 
 """
 
+["TO.CV.LOG"]
+prototype = "TO.CV.LOG x y"
+short = "translates the output for `CV` output `x` to logarithmic mode `y`; `y` defaults to `0` (off); mode `1` is for 0-16384 (0V-10V), mode `2` is for 0-8192 (0V-5V), mode `3` is for 0-4096 (0V-2.5V), etc."
+description = """
+The following example creates an envelope that ramps to 5V over a logarithmic curve:
+
+```
+TO.CV.SET 1 V 5
+TO.CV.LOG 1 2
+TO.ENV.ATT 1 500
+TO.ENV.DEC.S 1 2
+TO.ENV.ACT 1 1
+```
+
+When triggered (`TO.ENV.TRIG 1`), the envelope will rise to 5V over a half a second and then decay back to zero over two seconds. The curve used is `2`, which covers 0V-5V. 
+
+If a curve is too small for the range being covered, values above the range will be limited to the range's ceiling. In the above example, voltages above 5V will all return as 5V. 
+
+"""
+
 ["TO.OSC"]
-prototype_set = "TO.OSC x y"
+prototype = "TO.OSC x y"
 short = "targets oscillation for CV output `x` to `y` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is 1v/oct translated from the standard range (1-16384); a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 description = """
 Setting an `OSC` frequency greater than zero for a `CV` output will start that output oscillating. It will swing its voltage between to the current `CV` value and its polar opposite. For example:
@@ -208,43 +274,67 @@ If you want to go back to regular `CV` behavior, you need to set the oscillation
 """
 
 ["TO.OSC.SET"]
-prototype_set = "TO.OSC.SET x y"
+prototype = "TO.OSC.SET x y"
 short = "set oscillation for CV output `x` to `y` (ignores `CV.OSC.SLEW`); `y` is 1v/oct translated from the standard range (1-16384); a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 
 ["TO.OSC.QT"]
-prototype_set = "TO.OSC.QT x y"
+prototype = "TO.OSC.QT x y"
 short = "targets oscillation for CV output `x` to `y` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is 1v/oct translated from the standard range (1-16384) and quantized to current `OSC.SCALE`; a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 
 ["TO.OSC.QT.SET"]
-prototype_set = "TO.OSC.QT.SET x y"
+prototype = "TO.OSC.QT.SET x y"
 short = "set oscillation for CV output `x` to `y` (ignores `CV.OSC.SLEW`); `y` is 1v/oct translated from the standard range (1-16384) and quantized to current `OSC.SCALE`; a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 
 ["TO.OSC.N"]
-prototype_set = "TO.OSC.N x y"
+prototype = "TO.OSC.N x y"
 short = "targets oscillation for CV output `x` to note `y` with the portamento rate determined by the `TO.OSC.SLEW` value; see quantization scale reference for `y`; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 
 ["TO.OSC.N.SET"]
-prototype_set = "TO.OSC.N.SET x y"
+prototype = "TO.OSC.N.SET x y"
 short = "sets oscillation for CV output `x` to note `y` (ignores `CV.OSC.SLEW`); see quantization scale reference for `y`; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 
 ["TO.OSC.FQ"]
-prototype_set = "TO.OSC.FQ x y"
+prototype = "TO.OSC.FQ x y"
 short = "targets oscillation for CV output `x` to frequency `y` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in Hz; a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 
 ["TO.OSC.FQ.SET"]
-prototype_set = "TO.OSC.FQ x y"
+prototype = "TO.OSC.FQ x y"
 short = "sets oscillation for CV output `x` to frequency `y` (ignores `CV.OSC.SLEW`); `y` is in Hz; a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 
 ["TO.OSC.LFO"]
-prototype_set = "TO.OSC.LFO x y"
+prototype = "TO.OSC.LFO x y"
 short = "targets oscillation for CV output `x` to LFO frequency `y` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in mHz (millihertz: 10^-3 Hz); a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 
 ["TO.OSC.LFO.SET"]
-prototype_set = "TO.OSC.LFO.SET x y"
+prototype = "TO.OSC.LFO.SET x y"
 short = "sets oscillation for CV output `x` to LFO frequency `y` (ignores `CV.OSC.SLEW`); `y` is in mHz (millihertz: 10^-3 Hz); a value of `0` disables oscillation; `CV` amplitude is used as the peak for oscillation and needs to be `> 0` for it to be perceivable"
 
+["TO.OSC.CYC"]
+prototype = "TO.OSC.CYC x y"
+short = "targets the oscillator cycle length to `y` for CV output `x` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in milliseconds"
+
+["TO.OSC.CYC.SET"]
+prototype = "TO.OSC.CYC.SET x y"
+short = "sets the oscillator cycle length to `y` for CV output `x` (ignores `CV.OSC.SLEW`); `y` is in milliseconds"
+
+["TO.OSC.CYC.S"]
+prototype = "TO.OSC.CYC.S x y"
+short = "targets the oscillator cycle length to `y` for CV output `x` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in seconds"
+
+["TO.OSC.CYC.S.SET"]
+prototype = "TO.OSC.CYC.S.SET x y"
+short = "sets the oscillator cycle length to `y` for CV output `x` (ignores `CV.OSC.SLEW`); `y` is in seconds"
+
+["TO.OSC.CYC.M"]
+prototype = "TO.OSC.CYC.M x y"
+short = "targets the oscillator cycle length to `y` for CV output `x` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in minutes"
+
+["TO.OSC.CYC.M.SET"]
+prototype = "TO.OSC.CYC.M.SET x y"
+short = "sets the oscillator cycle length to `y` for CV output `x` (ignores `CV.OSC.SLEW`); `y` is in minutes"
+
 ["TO.OSC.SCALE"]
-prototype_set = "TO.OSC.SCALE x y"
+prototype = "TO.OSC.SCALE x y"
 short = "select scale # `y` for CV output `x`; scales listed in full description"
 description = """
 ### Quantization Scales
@@ -267,48 +357,12 @@ description = """
 16. Partch Greek scales from "Two Studies on Ancient Greek Scales" on black/white 
 """
 
-["TO.OSC.CYC"]
-prototype_set = "TO.OSC.CYC x y"
-short = "targets the oscillator cycle length to `y` for CV output `x` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in milliseconds"
-
-["TO.OSC.CYC.SET"]
-prototype_set = "TO.OSC.CYC.SET x y"
-short = "sets the oscillator cycle length to `y` for CV output `x` (ignores `CV.OSC.SLEW`); `y` is in milliseconds"
-
-["TO.OSC.CYC.S"]
-prototype_set = "TO.OSC.CYC.S x y"
-short = "targets the oscillator cycle length to `y` for CV output `x` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in seconds"
-
-["TO.OSC.CYC.S.SET"]
-prototype_set = "TO.OSC.CYC.S.SET x y"
-short = "sets the oscillator cycle length to `y` for CV output `x` (ignores `CV.OSC.SLEW`); `y` is in seconds"
-
-["TO.OSC.CYC.M"]
-prototype_set = "TO.OSC.CYC.M x y"
-short = "targets the oscillator cycle length to `y` for CV output `x` with the portamento rate determined by the `TO.OSC.SLEW` value; `y` is in minutes"
-
-["TO.OSC.CYC.M.SET"]
-prototype_set = "TO.OSC.CYC.M.SET x y"
-short = "sets the oscillator cycle length to `y` for CV output `x` (ignores `CV.OSC.SLEW`); `y` is in minutes"
-
 ["TO.OSC.WAVE"]
-prototype_set = "TO.OSC.WAVE x y"
+prototype = "TO.OSC.WAVE x y"
 short = "set the waveform for output `x` to `y`; `y` values range `0-4999`; values translate to sine (0), triangle (1000), saw (2000), pulse (3000), or noise (4000); oscillator shape between values is a blend of the pure waveforms"
 
-["TO.OSC.WIDTH"]
-prototype_set = "TO.OSC.WIDTH x y"
-short = "sets the width of the pulse wave on output `x` to `y`; `y` is a percentage of total width (0 to 100); only affects waveform `3000`"
-
-["TO.OSC.SYNC"]
-prototype_set = "TO.OSC.SYNC x"
-short = "resets the phase of the oscillator on `CV` output `x` (relative to `TO.OSC.PHASE`)"
-
-["TO.OSC.PHASE"]
-prototype_set = "TO.OSC.PHASE x y"
-short = "sets the phase offset of the oscillator on CV output `x` to `y` (0 to 16383); `y` is the range of one cycle"
-
 ["TO.OSC.RECT"]
-prototype_set = "TO.OSC.RECT x y"
+prototype = "TO.OSC.RECT x y"
 short = "rectifies the polarity of the oscillator for output `x` to `y`; range for `y` is -2 to 2; default is 0 (no rectification); 1 & -1 are partial rectification - omitting all values on the other side of the sign; 2 & -2 are full rectification - inverting values from the other pole"
 description = """
 The rectification command performs a couple of levels of rectification based on how you have it set. The following values for `y` work as follows:
@@ -319,8 +373,20 @@ The rectification command performs a couple of levels of rectification based on 
 * `y = -2`: "full-negative" - inverts positive values, making them negative
 """
 
+["TO.OSC.WIDTH"]
+prototype = "TO.OSC.WIDTH x y"
+short = "sets the width of the pulse wave on output `x` to `y`; `y` is a percentage of total width (0 to 100); only affects waveform `3000`"
+
+["TO.OSC.SYNC"]
+prototype = "TO.OSC.SYNC x"
+short = "resets the phase of the oscillator on `CV` output `x` (relative to `TO.OSC.PHASE`)"
+
+["TO.OSC.PHASE"]
+prototype = "TO.OSC.PHASE x y"
+short = "sets the phase offset of the oscillator on CV output `x` to `y` (0 to 16383); `y` is the range of one cycle"
+
 ["TO.OSC.SLEW"]
-prototype_set = "TO.OSC.SLEW x y"
+prototype = "TO.OSC.SLEW x y"
 short = "sets the frequency slew time (portamento) for the oscillator on CV output `x` to `y`; `y` in milliseconds"
 description = """
 This parameter acts as a frequency slew for the targeted `CV` output. It allows you to gradually slide from one frequency to another, creating a portamento like effect. It is also great for smoothing transitions between different `LFO` rates on the oscillator. For example:
@@ -336,15 +402,28 @@ This will start an LFO on `CV 1` with a rate of 1000mHz. Then, over the next 30 
 """
 
 ["TO.OSC.SLEW.S"]
-prototype_set = "TO.OSC.SLEW.S x y"
+prototype = "TO.OSC.SLEW.S x y"
 short = "sets the frequency slew time (portamento) for the oscillator on CV output `x` to `y`; `y` in seconds"
 
 ["TO.OSC.SLEW.M"]
-prototype_set = "TO.OSC.SLEW.M x y"
+prototype = "TO.OSC.SLEW.M x y"
 short = "sets the frequency slew time (portamento) for the oscillator on CV output `x` to `y`; `y` in minutes"
 
+["TO.OSC.CTR"]
+prototype = "TO.OSC.CTR x y"
+short = "centers the oscillation on CV output `x` to `y`; `y` values are bipolar (-16384 to +16383) and map to -10 to +10"
+description = """
+For example, to create a sine wave that is centered at 2.5V and swings up to +5V and down to 0V, you would do this:
+
+'''
+TO.CV 1 VV 250
+TO.OSC.CTR 1 VV 250
+TO.OSC.LFO 1 500
+```
+"""
+
 ["TO.ENV.ACT"]
-prototype_set = "TO.ENV.ACT x y"
+prototype = "TO.ENV.ACT x y"
 short = "activates/deactivates the AD envelope generator for the CV output `x`; `y` turns the envelope generator off (0 - default) or on (1);  `CV` amplitude is used as the peak for the envelope and needs to be `> 0` for the envelope to be perceivable"
 description = """
 This setting activates (1) or deactivates (0) the envelope generator on `CV` output `y`. The envelope generator is dependent on the current voltage setting for the output. Upon activation, the targeted output will go to zero. Then, when triggered (`TO.ENV.TRIG`), it will ramp the voltage from zero to the currently set peak voltage (`TO.CV`) over the attack time (`TO.ENV.ATT`) and then decay back to zero over the decay time (`TO.ENV.DEC`). For example:
@@ -362,41 +441,75 @@ To return your `CV` output to normal function, either deactivate the envelope (`
 """
 
 ["TO.ENV.TRIG"]
-prototype_set = "TO.ENV.TRIG x"
+prototype = "TO.ENV.TRIG x"
 short = "triggers the envelope at `CV` output `x` to cycle;  `CV` amplitude is used as the peak for the envelope and needs to be `> 0` for the envelope to be perceivable"
 
 ["TO.ENV.ATT"]
-prototype_set = "TO.ENV.ATT x y"
+prototype = "TO.ENV.ATT x y"
 short = "set the envelope attack time to `y` for `CV` output `x`; `y` in milliseconds (default 12 ms)"
 
 ["TO.ENV.ATT.S"]
-prototype_set = "TO.ENV.ATT.S x y"
+prototype = "TO.ENV.ATT.S x y"
 short = "set the envelope attack time to `y` for `CV` output `x`; `y` in seconds"
 
 ["TO.ENV.ATT.M"]
-prototype_set = "TO.ENV.ATT.M x y"
+prototype = "TO.ENV.ATT.M x y"
 short = "set the envelope attack time to `y` for `CV` output `x`; `y` in minutes"
 
 ["TO.ENV.DEC"]
-prototype_set = "TO.ENV.DEC x y"
+prototype = "TO.ENV.DEC x y"
 short = "set the envelope decay time to `y` for `CV` output `x`; `y` in milliseconds (default 250 ms)"
 
 ["TO.ENV.DEC.S"]
-prototype_set = "TO.ENV.DEC.S x y"
+prototype = "TO.ENV.DEC.S x y"
 short = "set the envelope decay time to `y` for `CV` output `x`; `y` in seconds"
 
 ["TO.ENV.DEC.M"]
-prototype_set = "TO.ENV.DEC.M x y"
+prototype = "TO.ENV.DEC.M x y"
 short = "set the envelope decay time to `y` for `CV` output `x`; `y` in minutes"
 
+["TO.ENV.EOR"]
+prototype = "TO.ENV.EOR x n"
+short = "fires a `PULSE` at the End of Rise to the unit-local trigger output 'n' for the envelope on `CV` output `x`; `n` refers to trigger output 1-4 on the same TXo as CV output 'y'"
+description = """
+The most important thing to know with this operator is that you can only cause the EOR trigger to fire on the same device as the TXo with the envelope. For this command, the outputs are numbered LOCALLY to the unit with the envelope.
+
+For example, if you have an envelope running on your second TXo, you can only send the EOR pulse to the four outputs on that device:
+
+```
+TO.ENV.EOR 5 1
+```
+
+This will cause the first output on TXo #2 (`TO.TR 5`) to pulse after the envelope's attack segment.
+"""
+
+["TO.ENV.EOC"]
+prototype = "TO.ENV.EOC x n"
+short = "fires a `PULSE` at the End of Cycle to the unit-local trigger output 'n' for the envelope on `CV` output `x`; `n` refers to trigger output 1-4 on the same TXo as CV output 'y'"
+description = """
+The most important thing to know with this operator is that you can only cause the EOC trigger to fire on the same device as the TXo with the envelope. For this command, the outputs are numbered LOCALLY to the unit with the envelope.
+
+For example, if you have an envelope running on your second TXo, you can only send the EOC pulse to the four outputs on that device:
+
+```
+TO.ENV.EOC 5 1
+```
+
+This will cause the first output on TXo #2 (`TO.TR 5`) to pulse after the envelope's decay segment.
+"""
+
+["TO.ENV.LOOP"]
+prototype = "TO.ENV.LOOP x y"
+short = "causes the envelope on `CV` output `x` to loop for `y` times; a `y` of `0` will cause the envelope to loop infinitely; setting `y` to 1 (default) disables looping and (if currently looping) will cause it to finish its current cycle and cease"
+
 ["TO.TR.INIT"]
-prototype_set = "TO.TR.INIT x"
+prototype = "TO.TR.INIT x"
 short = "initializes `TR` output `x` back to the default boot settings and behaviors; neutralizes metronomes, dividers, pulse counters, etc."
 
 ["TO.CV.INIT"]
-prototype_set = "TO.CV.INIT x"
+prototype = "TO.CV.INIT x"
 short = "initializes `CV` output `x` back to the default boot settings and behaviors; neutralizes offsets, slews, envelopes, oscillation, etc."
 
 ["TO.INIT"]
-prototype_set = "TO.INIT d"
+prototype = "TO.INIT d"
 short = "initializes all of the `TR` and `CV` outputs for device number `d` (1-8)"


### PR DESCRIPTION
Please find the documentation for the TXo and TXi in this pull request. Includes all operators with short descriptions and selected long descriptions for the more complex, TELEX-exclusive operators.